### PR TITLE
check cargo_selection before lipo and upgrade target-lexicon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.11"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
+checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.6"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
+checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 yansi = "0.5"
 fs-err = "2.9"
-target-lexicon = { version = "0.12", features = ["serde_support"] }
+target-lexicon = { version = "0.12.11", features = ["serde_support"] }
 rustup-configurator = "0.1"
 lazy_static = "1.4"
 dialoguer = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 yansi = "0.5"
 fs-err = "2.9"
-target-lexicon = { version = "0.12.11", features = ["serde_support"] }
+target-lexicon = { version = "0.12", features = ["serde_support"] }
 rustup-configurator = "0.1"
 lazy_static = "1.4"
 dialoguer = "0.10"

--- a/src/cmd/lipo.rs
+++ b/src/cmd/lipo.rs
@@ -6,17 +6,23 @@ pub fn assemble_libs(conf: &Configuration) -> Result<Vec<String>> {
     fs_err::create_dir_all(&conf.build_dir.join("libs"))?;
 
     let mut libs = vec![];
-    libs.push(join_or_copy(conf, &conf.cargo_section.iOS_targets, "ios")?);
-    libs.push(join_or_copy(
-        conf,
-        &conf.cargo_section.iOS_simulator_targets,
-        "ios_sim",
-    )?);
-    libs.push(join_or_copy(
-        conf,
-        &conf.cargo_section.macOS_targets,
-        "macos",
-    )?);
+    if conf.cargo_section.iOS {
+        libs.push(join_or_copy(conf, &conf.cargo_section.iOS_targets, "ios")?);
+    }
+    if conf.cargo_section.simulators {
+        libs.push(join_or_copy(
+            conf,
+            &conf.cargo_section.iOS_simulator_targets,
+            "ios_sim",
+        )?);
+    }
+    if conf.cargo_section.macOS {
+        libs.push(join_or_copy(
+            conf,
+            &conf.cargo_section.macOS_targets,
+            "macos",
+        )?);
+    }
 
     Ok(libs)
 }


### PR DESCRIPTION
### Check `cargo_selection`

We may not want to build a target like macOS. So it is better to check the configuration before using lipo.

### Upgrade `target-lexicon`

I'm also upgrading target-lexicon due to this error:
```
    Rustup returned an invalid triple 'loongarch64-unknown-linux-gnu' due to 'Unrecognized architecture: loongarch64', please raise an issue at: https://
github.com/akesson/rustup-target/issues
```