### PR TITLE
Add dynamic SDK version and deployment target to Info.plist

### DIFF
--- a/src/core/platform.rs
+++ b/src/core/platform.rs
@@ -75,6 +75,27 @@ impl ApplePlatform {
         }
     }
 
+    /// Returns the environment variable name for the deployment target of this platform.
+    pub fn deployment_target_env_var(&self) -> &'static str {
+        match self {
+            ApplePlatform::MacOS => "MACOSX_DEPLOYMENT_TARGET",
+            ApplePlatform::IOS(_) => "IPHONEOS_DEPLOYMENT_TARGET",
+            ApplePlatform::TvOS(_) => "TVOS_DEPLOYMENT_TARGET",
+            ApplePlatform::WatchOS(_) => "WATCHOS_DEPLOYMENT_TARGET",
+        }
+    }
+
+    /// Returns the default minimum deployment target for this platform,
+    /// matching the Rust compiler's defaults.
+    pub fn default_deployment_target(&self) -> &'static str {
+        match self {
+            ApplePlatform::MacOS => "10.12",
+            ApplePlatform::IOS(_) => "10.0",
+            ApplePlatform::TvOS(_) => "10.0",
+            ApplePlatform::WatchOS(_) => "5.0",
+        }
+    }
+
     // Reference: https://doc.rust-lang.org/rustc/platform-support.html
     pub fn rustup_targets(&self) -> Vec<&str> {
         match self {
@@ -97,5 +118,51 @@ impl ApplePlatform {
                 vec!["x86_64-apple-watchos", "aarch64-apple-tvos-sim"]
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deployment_target_env_vars() {
+        assert_eq!(
+            ApplePlatform::MacOS.deployment_target_env_var(),
+            "MACOSX_DEPLOYMENT_TARGET"
+        );
+        assert_eq!(
+            ApplePlatform::IOS(Environment::Device).deployment_target_env_var(),
+            "IPHONEOS_DEPLOYMENT_TARGET"
+        );
+        assert_eq!(
+            ApplePlatform::IOS(Environment::Simulator).deployment_target_env_var(),
+            "IPHONEOS_DEPLOYMENT_TARGET"
+        );
+        assert_eq!(
+            ApplePlatform::TvOS(EnvironmentWithoutCatalyst::Device).deployment_target_env_var(),
+            "TVOS_DEPLOYMENT_TARGET"
+        );
+        assert_eq!(
+            ApplePlatform::WatchOS(EnvironmentWithoutCatalyst::Device).deployment_target_env_var(),
+            "WATCHOS_DEPLOYMENT_TARGET"
+        );
+    }
+
+    #[test]
+    fn default_deployment_targets() {
+        assert_eq!(ApplePlatform::MacOS.default_deployment_target(), "10.12");
+        assert_eq!(
+            ApplePlatform::IOS(Environment::Device).default_deployment_target(),
+            "10.0"
+        );
+        assert_eq!(
+            ApplePlatform::TvOS(EnvironmentWithoutCatalyst::Simulator).default_deployment_target(),
+            "10.0"
+        );
+        assert_eq!(
+            ApplePlatform::WatchOS(EnvironmentWithoutCatalyst::Device).default_deployment_target(),
+            "5.0"
+        );
     }
 }

--- a/src/core/plist.rs
+++ b/src/core/plist.rs
@@ -3,31 +3,32 @@ use super::platform::ApplePlatform;
 pub struct InfoPlistBuilder {
     bundle_name: String,
     platform: ApplePlatform,
+    sdk_version: String,
+    min_os_version: String,
 }
 
 impl InfoPlistBuilder {
-    pub fn new(bundle_name: &str, platform: ApplePlatform) -> Self {
+    pub fn new(
+        bundle_name: &str,
+        platform: ApplePlatform,
+        sdk_version: String,
+        min_os_version: String,
+    ) -> Self {
         Self {
             bundle_name: bundle_name.into(),
             platform,
+            sdk_version,
+            min_os_version,
         }
-    }
-
-    pub fn bundle_name(mut self, bundle_name: &str) -> Self {
-        self.bundle_name = bundle_name.to_string();
-        self
-    }
-
-    pub fn platform(mut self, platform: ApplePlatform) -> Self {
-        self.platform = platform;
-        self
     }
 
     pub fn write(&self, path: &str) -> std::io::Result<()> {
         let template = TEAMPLATE
             .replace("{BUNDLE_NAME}", &self.bundle_name)
             .replace("{SUPPORTED_PLATFORM}", self.platform.platform_name())
-            .replace("{PLATFORM_NAME}", self.platform.platform_display_name());
+            .replace("{PLATFORM_NAME}", self.platform.platform_name())
+            .replace("{SDK_VERSION}", &self.sdk_version)
+            .replace("{MIN_OS_VERSION}", &self.min_os_version);
         std::fs::write(path, template)
     }
 }
@@ -58,9 +59,123 @@ const TEAMPLATE: &str = r###"
 	<key>DTPlatformName</key>
 	<string>{PLATFORM_NAME}</string>
 	<key>DTSDKName</key>
-	<string>iphonesimulator13.0</string>
+	<string>{PLATFORM_NAME}{SDK_VERSION}</string>
 	<key>MinimumOSVersion</key>
-	<string>13.0</string>
+	<string>{MIN_OS_VERSION}</string>
 </dict>
 </plist>
 "###;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::platform::{Environment, EnvironmentWithoutCatalyst};
+
+    #[test]
+    fn plist_platform_values_match_sdk_identifiers() {
+        let platforms = vec![
+            (ApplePlatform::MacOS, "17.0", "10.12"),
+            (ApplePlatform::IOS(Environment::Device), "18.0", "15.0"),
+            (ApplePlatform::IOS(Environment::Simulator), "18.0", "15.0"),
+            (ApplePlatform::IOS(Environment::Catalyst), "18.0", "15.0"),
+            (
+                ApplePlatform::TvOS(EnvironmentWithoutCatalyst::Device),
+                "18.0",
+                "16.0",
+            ),
+            (
+                ApplePlatform::TvOS(EnvironmentWithoutCatalyst::Simulator),
+                "18.0",
+                "16.0",
+            ),
+            (
+                ApplePlatform::WatchOS(EnvironmentWithoutCatalyst::Device),
+                "11.0",
+                "9.0",
+            ),
+            (
+                ApplePlatform::WatchOS(EnvironmentWithoutCatalyst::Simulator),
+                "11.0",
+                "9.0",
+            ),
+        ];
+
+        for (platform, sdk_version, min_os_version) in platforms {
+            let expected_name = platform.platform_name();
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("Info.plist");
+            let path_str = path.to_str().unwrap();
+
+            InfoPlistBuilder::new(
+                "TestBundle",
+                platform,
+                sdk_version.to_string(),
+                min_os_version.to_string(),
+            )
+            .write(path_str)
+            .unwrap();
+
+            let contents = std::fs::read_to_string(path_str).unwrap();
+
+            // DTPlatformName should be the SDK identifier
+            let dt_platform = extract_plist_value(&contents, "DTPlatformName");
+            assert_eq!(
+                dt_platform, expected_name,
+                "DTPlatformName mismatch for {expected_name}"
+            );
+
+            // DTSDKName should be platform name + SDK version
+            let dt_sdk = extract_plist_value(&contents, "DTSDKName");
+            let expected_sdk = format!("{expected_name}{sdk_version}");
+            assert_eq!(
+                dt_sdk, expected_sdk,
+                "DTSDKName mismatch for {expected_name}"
+            );
+
+            // MinimumOSVersion should match the provided value
+            let min_os = extract_plist_value(&contents, "MinimumOSVersion");
+            assert_eq!(
+                min_os, min_os_version,
+                "MinimumOSVersion mismatch for {expected_name}"
+            );
+        }
+    }
+
+    #[test]
+    fn plist_with_empty_sdk_version() {
+        let platform = ApplePlatform::MacOS;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Info.plist");
+        let path_str = path.to_str().unwrap();
+
+        InfoPlistBuilder::new("TestBundle", platform, String::new(), "10.0".to_string())
+            .write(path_str)
+            .unwrap();
+
+        let contents = std::fs::read_to_string(path_str).unwrap();
+
+        // DTSDKName should be just the platform name with no trailing version
+        let dt_sdk = extract_plist_value(&contents, "DTSDKName");
+        assert_eq!(
+            dt_sdk, "macosx",
+            "DTSDKName should be just platform name when sdk_version is empty"
+        );
+
+        // MinimumOSVersion should still be set correctly
+        let min_os = extract_plist_value(&contents, "MinimumOSVersion");
+        assert_eq!(min_os, "10.0", "MinimumOSVersion should still be set");
+    }
+
+    fn extract_plist_value(plist: &str, key: &str) -> String {
+        let key_tag = format!("<key>{key}</key>");
+        let after_key = plist.split(&key_tag).nth(1).unwrap();
+        let value = after_key
+            .split("<string>")
+            .nth(1)
+            .unwrap()
+            .split("</string>")
+            .next()
+            .unwrap();
+        value.to_string()
+    }
+}


### PR DESCRIPTION
## Summary

- Query SDK version via `xcrun --show-sdk-version` so `DTSDKName` reflects the actual installed SDK
- Resolve deployment targets from environment variables (e.g. `IPHONEOS_DEPLOYMENT_TARGET`) with sensible defaults matching the Rust compiler, so `MinimumOSVersion` is accurate
- Add `deployment_target_env_var()` and `default_deployment_target()` methods to `ApplePlatform`
- Update `InfoPlistBuilder` to accept `sdk_version` and `min_os_version` parameters
- Replace hardcoded plist values with dynamic template placeholders

Closes #26

## Test plan

- [x] `resolve_deployment_target` reads from env var when set
- [x] `resolve_deployment_target` falls back to platform default when env var is unset
- [x] `query_sdk_version` returns a valid version string (xcrun integration)
- [x] Plist rendering verified across all 8 platform variants
- [x] Edge case: empty SDK version produces correct `DTSDKName`
- [x] `cargo test` — all 7 unit tests + 3 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)