### PR TITLE
Fix zip-extensions API breakage after 0.9 to 0.13 update

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -190,7 +190,7 @@ pub fn compress_xcframework(
     };
     let dest = output_dir.join(zip_name);
     let source = xcframework_path;
-    zip_extensions::zip_create_from_directory(
+    zip_extensions::zip_writer::zip_create_from_directory(
         &dest.clone().into_std_path_buf(),
         &source.clone().into_std_path_buf(),
     )?;


### PR DESCRIPTION
## Summary

- PR #31 updated `zip-extensions` from `0.9` to `0.13`, which moved `zip_create_from_directory` from the crate root to `zip_extensions::zip_writer`
- Updates the fully-qualified path in `src/core.rs` to fix the compilation error

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo check` compiles successfully
- [x] `cargo test` — all 10 tests pass
- [x] `cargo build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)